### PR TITLE
add POST endpoint for add-result

### DIFF
--- a/functions/add-result/add-result.js
+++ b/functions/add-result/add-result.js
@@ -1,0 +1,55 @@
+const faunadb = require('faunadb');
+require('dotenv').config();
+
+const faunaClient = new faunadb.Client({
+  secret: process.env.FAUNADB_SERVER_SECRET,
+});
+
+const q = faunadb.query;
+
+exports.handler = async event => {
+  // checks to ensure this request is a POST
+  if (event.httpMethod !== 'POST') {
+    return {
+      body: 'Method Not Allowed. POST route only.',
+      statusCode: 405,
+    };
+  }
+
+  try {
+    // parses the request body
+    const { amount, gameType, name } = JSON.parse(event.body);
+
+    // gets the current wins of the player
+    const { data: winsData } = await faunaClient.query(
+      q.Get(q.Match(q.Index(`${gameType}_wins_by_name`), name)),
+    );
+
+    const { wins } = winsData;
+
+    // calculates the new number of wins
+    const updatedWins = wins + (amount || 1);
+
+    // updates the user's document in the proper gameType collection
+    const { data: updatedData } = await faunaClient.query(
+      q.Update(
+        q.Select(['ref'], q.Get(q.Match(q.Index(`${gameType}_by_name`), name))),
+        {
+          data: {
+            wins: updatedWins,
+          },
+        },
+      ),
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(updatedData),
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ msg: err.message }),
+    };
+  }
+};

--- a/functions/leaderboards/leaderboards.js
+++ b/functions/leaderboards/leaderboards.js
@@ -7,20 +7,52 @@ const faunaClient = new faunadb.Client({
 
 const q = faunadb.query;
 
-exports.handler = async () => {
+exports.handler = async event => {
+  // checks to ensure this request is a POST
+  if (event.httpMethod !== 'GET') {
+    return {
+      body: 'Method Not Allowed. GET route only.',
+      statusCode: 405,
+    };
+  }
+
   try {
-    const req = await faunaClient.query(
+    // gets the player data from the horse collection
+    const horseData = await faunaClient.query(
       q.Map(
         q.Paginate(q.Documents(q.Collection('horse'))),
         q.Lambda(x => q.Get(x)),
       ),
     );
 
-    const horse = req.data.map(player => player.data);
+    // gets the player data from the twentyOne collection
+    const twentyOneData = await faunaClient.query(
+      q.Map(
+        q.Paginate(q.Documents(q.Collection('twentyOne'))),
+        q.Lambda(x => q.Get(x)),
+      ),
+    );
+
+    // gets the player data from the oneOnOne collection
+    const oneOnOneData = await faunaClient.query(
+      q.Map(
+        q.Paginate(q.Documents(q.Collection('oneOnOne'))),
+        q.Lambda(x => q.Get(x)),
+      ),
+    );
+
+    // maps for the just the player data and excludes unnecessary database data
+    const horse = horseData.data.map(player => player.data);
+    const twentyOne = twentyOneData.data.map(player => player.data);
+    const oneOnOne = oneOnOneData.data.map(player => player.data);
 
     return {
       statusCode: 200,
-      body: JSON.stringify({ horse, oneOnOne: [], twentyOne: [] }),
+      body: JSON.stringify({
+        horse,
+        oneOnOne,
+        twentyOne,
+      }),
     };
   } catch (err) {
     return {


### PR DESCRIPTION
This pull requests adds a `POST` endpoint called `/add-result` that expects the data shape of:

```ts
{
  name: string;
  gameType: string;
  amount?: number;
}
```

and returns the data of the newly updated user:

```ts
{
  name: string;
  wins: number;
}
```