### PR TITLE
fix: add redirect config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,8 @@
   from = "/api/*"
   to = "/.netlify/functions/:splat"
   status = 200
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
### Description

This pull request fixes the issue where `/addgame` shows a `404` error.

Found this fix [here](https://docs.netlify.com/routing/redirects/#syntax-for-the-netlify-configuration-file).
