### PR TITLE
fix: convert amount to Number

### DIFF
--- a/functions/add-result/add-result.js
+++ b/functions/add-result/add-result.js
@@ -28,7 +28,7 @@ exports.handler = async event => {
     const { wins } = winsData;
 
     // calculates the new number of wins
-    const updatedWins = wins + (amount || 1);
+    const updatedWins = wins + (Number(amount) || 1);
 
     // updates the user's document in the proper gameType collection
     const { data: updatedData } = await faunaClient.query(


### PR DESCRIPTION
### Description

This pull request converts `amount` to a `Number` type so that the `amount` can be added to the current amount of wins in the database.
