### PR TITLE
feat: add some basic form validation

### DIFF
--- a/src/components/AddGame/AddGame.js
+++ b/src/components/AddGame/AddGame.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import GamesDropDown from '../GamePage/GamesDropDown';
@@ -7,11 +7,14 @@ import PickPlayerDD from '../GamePage/PickPlayerDD';
 
 import './AddGame.css';
 
+const isANumber = value => !Number.isNaN(Number(value));
+
 export default function AddGame() {
   const history = useHistory();
   const [player, setPlayer] = useState('');
   const [game, setGame] = useState('');
-  const [wins, setWins] = useState();
+  const [wins, setWins] = useState('');
+  const [disabled, setDisabled] = useState(true);
 
   const handleFormSubmit = async event => {
     event.preventDefault();
@@ -22,14 +25,24 @@ export default function AddGame() {
     });
     history.push('/');
   };
+
+  useEffect(() => {
+    if (player && game && isANumber(wins)) {
+      setDisabled(false);
+    } else {
+      setDisabled(true);
+    }
+  }, [game, player, wins]);
+
   return (
     <>
       <h1 className="heading">Add a Game</h1>
       <form>
         <PickPlayerDD setPlayer={setPlayer} />
         <GamesDropDown setGame={setGame} />
-        <DidYouWin setWins={setWins} />
+        <DidYouWin setWins={setWins} wins={wins} />
         <button
+          disabled={disabled}
           className="negative ui button"
           type="submit"
           onClick={handleFormSubmit}

--- a/src/components/GamePage/DidYouWin.js
+++ b/src/components/GamePage/DidYouWin.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import './DidYouWin.css';
 
-export default function DidYouWin({ setWins }) {
+export default function DidYouWin({ setWins, wins }) {
   return (
     <div className="input-box">
       <div className=" ui input">
@@ -10,6 +10,7 @@ export default function DidYouWin({ setWins }) {
           className="winner"
           type="text"
           placeholder="How many games did you win?"
+          value={wins}
         />
       </div>
     </div>


### PR DESCRIPTION
### Description

This pull request adds some basic form validation so that users are required to choose a player and a game type before they can submit results. The `wins` input is optional, but if they do enter something, it must be a `number`. Otherwise, the `submit` `button` is `disabled`.
