### PR TITLE
ci: add automerge action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,27 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: 'pascalgn/automerge-action@v0.12.0'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
### Description

This pull request adds another Github Action. This Github Action will automerge PR's, if you add the `automerge` label to the PR. It will only automerge if the other jobs pass and the PR has the necessary approvals.

I literally copy and pasted from the Github Action repo:
https://github.com/pascalgn/automerge-action