### PR TITLE
fix: server env logic

### DIFF
--- a/functions/add-result/add-result.js
+++ b/functions/add-result/add-result.js
@@ -2,7 +2,7 @@ const faunadb = require('faunadb');
 require('dotenv').config();
 
 const getServerSecret = () => {
-  if (process.env.NETLIFY_DEV) {
+  if (process.env.NETLIFY_DEV === 'true') {
     return process.env.FAUNADB_SERVER_SECRET_QA;
   }
 

--- a/functions/leaderboards/leaderboards.js
+++ b/functions/leaderboards/leaderboards.js
@@ -2,7 +2,7 @@ const faunadb = require('faunadb');
 require('dotenv').config();
 
 const getServerSecret = () => {
-  if (process.env.NETLIFY_DEV) {
+  if (process.env.NETLIFY_DEV === 'true') {
     return process.env.FAUNADB_SERVER_SECRET_QA;
   }
 


### PR DESCRIPTION
### Description

This pull request fixes the server env logic. `process.env.NETLIFY_DEV` is either `"true"` or `"false"` and since they are both strings, they are both truthy. I was thinking they were booleans `true` or `false`. I refactored the logic to check explicitly for string `"true"`.
